### PR TITLE
Improve logging: use project logs directory, add error handling, and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ src/.env
 # OS specific files
 .DS_Store
 Thumbs.db
+
+# Logs
+logs/

--- a/src/org_summary.py
+++ b/src/org_summary.py
@@ -9,16 +9,19 @@ pd.set_option('display.max_columns', None)
 pd.set_option('display.width', None)           # Prevent line wrapping
 pd.set_option('display.max_colwidth', None)    # Show full column content
 
-log_dir = '../../'
+log_dir = 'logs'
 os.makedirs(log_dir, exist_ok=True)  # Create directory if it doesn't exist
 log_file_path = os.path.join(log_dir, 'app.log')
 
-logging.basicConfig(
-    filename= log_file_path,           # Log file name
-    filemode='a',                 # Append mode ('w' to overwrite)
-    level=logging.INFO,           # Minimum log level
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
+try:
+    logging.basicConfig(
+        filename=log_file_path,           # Log file name
+        level=logging.INFO,               # Log level
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+except Exception as e:
+    print(f"Could not set up logging to {log_file_path}: {e}")
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
 
@@ -147,7 +150,7 @@ def generate_summary(coverage_data_objects, group_by='opportunity'):
     # change the date format of 'date_last_active' in 'DD-MM-YYYY'
     combined_summary['date_last_active'] = combined_summary['date_last_active'].dt.strftime('%m-%d-%Y')
 
-    # sort the 'combined_summary' data frame with '‘dus_per_day_mavrg’ ', 'days_since_active' , highest number on top
+    # sort the 'combined_summary' data frame with '‘dus_per_day_mavrg' ', 'days_since_active' , highest number on top
     combined_summary = combined_summary.sort_values(by='dus_per_day_mavrg', ascending=True)
 
     


### PR DESCRIPTION
This PR improves the logging setup to be more robust and user-friendly:

- Log files are now written to logs/app.log inside the project directory.
- The logs directory is created automatically if it doesn't exist.
- If the log file cannot be created (e.g., due to permissions), a clear error message is printed and logging falls back to the console.
- The logs/ directory is now in .gitignore, so log files won’t be committed to the repository.

These changes should not break compatibility for users with different environments or package versions, as only the logging setup is affected.